### PR TITLE
fix: Fix error 'address host value must be string'

### DIFF
--- a/bin/sony-headphones-control
+++ b/bin/sony-headphones-control
@@ -24,7 +24,7 @@ if len(service_matches) == 0:
 
 first_match = service_matches[0]
 port = first_match["port"]
-host = first_match["host"]
+host = str(first_match["host"], 'utf-8')
 
 ambientSoundBytes = None
 


### PR DESCRIPTION
Fixed Error `TypeError: address host value must be string, was <class 'bytes'>`